### PR TITLE
Add example of using secrets on windows

### DIFF
--- a/content/en/docs/getting-started-guides/windows/_index.md
+++ b/content/en/docs/getting-started-guides/windows/_index.md
@@ -50,7 +50,29 @@ Sample: stop web service to trigger restart
 
 #### Handling secrets
 
-Sample: database connection string
+1. Create a secret by following the [standard directions](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-secret)
+
+2. Configure your pod to receive the secret via an environment variable.
+ {{< codenew file="windows/secret-pod.yaml" >}}
+ 
+3. Deploy the pod and verify that it is running:
+  ```bash
+  kubectl create -f https://k8s.io/docs/getting-started-guides/windows/secret-pod.yaml
+  kubectl get pod secret-envars-test-pod
+  ```
+4. Open a shell into the container running the pod:
+  ```bash
+  kubectl exec -it secret-envars-test-pod -- powershell
+  ```
+5. See that the secret is in the environment variable:
+  ```powershell
+  echo $env:SECRET_USERNAME $env:SECRET_PASSWORD
+  ```
+    You should see the output:
+    ```
+    my-app
+    39528$vdg7Jb
+    ```
 
 ### Deploying a stateful application
 

--- a/content/en/examples/windows/secret-pod.yaml
+++ b/content/en/examples/windows/secret-pod.yaml
@@ -1,32 +1,25 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mysecret
-type: Opaque
-data:
-  username: YWRtaW4=
-  password: MWYyZDFlMmU2N2Rm
-
 ---
-
 apiVersion: v1
 kind: Pod
 metadata:
-  name: my-secret-pod
+  name: secret-envars-test-pod
 spec:
   containers:
-  - name: my-secret-pod
-    image: microsoft/windowsservercore:1709
+  - name: envars-test-container
+    image: microsoft/windowsservercore:latest
+    imagePullPolicy: Never
+    command:
+    - ping
+    - -t
+    - localhost
     env:
-      - name: USERNAME
-        valueFrom:
-          secretKeyRef:
-            name: mysecret
-            key: username
-      - name: PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: mysecret
-            key: password
-  nodeSelector:
-    beta.kubernetes.io/os: windows
+    - name: SECRET_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: test-secret
+          key: username
+    - name: SECRET_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: test-secret
+          key: password


### PR DESCRIPTION
- This is based on the linux version of the instructions. I'm not sure what a "database connection string" would look like instead.
-  I'm not sure how to make the link https://k8s.io/docs/getting-started-guides/windows/secret-pod.yaml work (the linux instructions have this in the `kubectl create -f ...`)
- Strangely, the environment variable values have newlines in them. This seems to only occur on windows (we made a linux container with the same secrets, and those variables do not include newlines).

Signed-off-by: Ben Moss <bmoss@pivotal.io>
